### PR TITLE
Add Create Post Feature

### DIFF
--- a/backend/src/controllers/posts.js
+++ b/backend/src/controllers/posts.js
@@ -1,9 +1,33 @@
 const mockPosts = require('../data/mockPosts');
 
 const postsController = {
-  getFeedPosts: (req, res) => {
-    // In a real app, we would fetch posts based on user's following
-    // and paginate the results
+  createPost: async (req, res) => {
+    const { caption, imageUrl } = req.body;
+    const userId = req.user.id;
+
+    const newPost = {
+      id: mockPosts.length + 1,
+      user: {
+        id: userId,
+        username: req.user.username,
+        profilePicture: `https://api.multiavatar.com/${req.user.username}.svg`
+      },
+      image: imageUrl || 'https://picsum.photos/600/600?random=' + Date.now(),
+      caption,
+      likes: 0,
+      comments: [],
+      createdAt: new Date().toISOString()
+    };
+
+    mockPosts.unshift(newPost);
+
+    res.status(201).json({
+      success: true,
+      post: newPost
+    });
+  },
+
+  getAllPosts: (req, res) => {
     res.json({
       success: true,
       posts: mockPosts
@@ -21,7 +45,6 @@ const postsController = {
       });
     }
 
-    // Toggle like
     post.likes += 1;
 
     res.json({

--- a/backend/src/routes/posts.js
+++ b/backend/src/routes/posts.js
@@ -3,10 +3,10 @@ const router = express.Router();
 const postsController = require('../controllers/posts');
 const { protected } = require('../middleware/auth');
 
-// All post routes are protected
 router.use(protected);
 
-router.get('/', postsController.getFeedPosts);
+router.post('/', postsController.createPost);
+router.get('/', postsController.getAllPosts);
 router.post('/:postId/like', postsController.likePost);
 router.post('/:postId/comment', postsController.addComment);
 

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { HomeIcon, UserCircleIcon } from '@heroicons/react/24/outline';
+import CreatePostButton from './post/CreatePostButton';
+
+const Navbar = ({ onPostCreated }) => {
+  const { user, logout } = useAuth();
+
+  return (
+    <nav className="bg-white border-b border-gray-200 fixed top-0 left-0 right-0 z-10">
+      <div className="max-w-5xl mx-auto px-4">
+        <div className="flex justify-between items-center h-16">
+          <Link to="/" className="text-xl font-bold">Instamock</Link>
+          
+          <div className="flex items-center space-x-4">
+            <Link to="/" className="text-gray-700 hover:text-black">
+              <HomeIcon className="h-6 w-6" />
+            </Link>
+            
+            <CreatePostButton onPostCreated={onPostCreated} />
+            
+            <Link to={`/profile/${user?.username}`} className="text-gray-700 hover:text-black">
+              <UserCircleIcon className="h-6 w-6" />
+            </Link>
+            
+            <button
+              onClick={logout}
+              className="text-sm text-gray-700 hover:text-black"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/frontend/src/components/post/CreatePost.js
+++ b/frontend/src/components/post/CreatePost.js
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { XMarkIcon, PhotoIcon } from '@heroicons/react/24/outline';
+import axios from 'axios';
+
+const CreatePost = ({ onClose, onPostCreated }) => {
+  const [step, setStep] = useState(1);
+  const [selectedImage, setSelectedImage] = useState(null);
+  const [caption, setCaption] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleImageSelect = (e) => {
+    const file = e.target.files[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setSelectedImage(reader.result);
+        setStep(2);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+      // In a real app, we would upload the image to a storage service
+      // and get back a URL. Here we'll use a placeholder
+      const response = await axios.post('http://localhost:3001/api/posts', {
+        caption,
+        imageUrl: `https://picsum.photos/600/600?random=${Date.now()}`
+      });
+
+      onPostCreated(response.data.post);
+      onClose();
+    } catch (error) {
+      console.error('Error creating post:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg max-w-2xl w-full">
+        {/* Header */}
+        <div className="border-b p-4 flex items-center justify-between">
+          <button onClick={onClose}>
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+          <h2 className="text-lg font-semibold">Create New Post</h2>
+          {step === 2 && (
+            <button
+              className="text-blue-500 font-semibold disabled:opacity-50"
+              disabled={loading || !caption.trim()}
+              onClick={handleSubmit}
+            >
+              Share
+            </button>
+          )}
+        </div>
+
+        {/* Content */}
+        {step === 1 ? (
+          <div className="p-16 flex flex-col items-center justify-center">
+            <PhotoIcon className="h-24 w-24 text-gray-400" />
+            <p className="mt-4 text-xl">Drag photos and videos here</p>
+            <label className="mt-4 bg-blue-500 text-white px-4 py-2 rounded cursor-pointer">
+              Select from computer
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleImageSelect}
+              />
+            </label>
+          </div>
+        ) : (
+          <div className="flex h-[600px]">
+            {/* Image Preview */}
+            <div className="flex-1 bg-black flex items-center justify-center">
+              <img
+                src={selectedImage}
+                alt="Preview"
+                className="max-h-full max-w-full object-contain"
+              />
+            </div>
+
+            {/* Caption Input */}
+            <div className="w-[340px] border-l">
+              <textarea
+                placeholder="Write a caption..."
+                className="w-full p-4 h-40 resize-none focus:outline-none focus:ring-0 border-0"
+                value={caption}
+                onChange={(e) => setCaption(e.target.value)}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CreatePost;

--- a/frontend/src/components/post/CreatePostButton.js
+++ b/frontend/src/components/post/CreatePostButton.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
+import CreatePost from './CreatePost';
+
+const CreatePostButton = ({ onPostCreated }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsModalOpen(true)}
+        className="text-gray-700 hover:text-black"
+      >
+        <PlusCircleIcon className="h-6 w-6" />
+      </button>
+
+      {isModalOpen && (
+        <CreatePost
+          onClose={() => setIsModalOpen(false)}
+          onPostCreated={onPostCreated}
+        />
+      )}
+    </>
+  );
+};
+
+export default CreatePostButton;


### PR DESCRIPTION
This PR adds the create post functionality to the Instagram clone.

Features:
- Modal-based post creation interface
- Image upload preview
- Caption input
- Backend API for post creation
- Integration with the navbar

Frontend Changes:
- Added CreatePost modal component
- Added CreatePostButton component
- Updated Navbar to include create post button
- Added image preview and caption functionality

Backend Changes:
- Added create post endpoint
- Updated posts controller with create functionality
- Added route handling for post creation

To test:
1. Click the plus icon in the navbar
2. Select an image from your computer
3. Add a caption
4. Click Share to create the post

Note: In this mockup version, we're using placeholder images from picsum.photos instead of actual image uploads.